### PR TITLE
Fixed routes

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -23,7 +23,7 @@ class BookingsController < ApplicationController
     @booking.console = @console
 
     if @booking.save
-      redirect_to booked_consoles_path(current_user)
+      redirect_to booked_consoles_path
     else
       render :new
     end
@@ -40,7 +40,7 @@ class BookingsController < ApplicationController
     authorize @booking
 
     if @booking.update(booking_params)
-      redirect_to booked_consoles_path(current_user)
+      redirect_to booked_consoles_path
     else
       render :edit
     end
@@ -51,7 +51,7 @@ class BookingsController < ApplicationController
     @booking = Booking.find(params[:id])
     authorize @booking
     @booking.destroy
-    redirect_to booked_consoles_path(current_user)
+    redirect_to booked_consoles_path
   end
 
   # APPROVE OR DENY BUTTONS ONLY FOR OWNERS
@@ -63,7 +63,7 @@ class BookingsController < ApplicationController
 
     authorize @booking
 
-    redirect_to owned_consoles_path(current_user)
+    redirect_to owned_consoles_path
   end
 
   def deny
@@ -73,7 +73,7 @@ class BookingsController < ApplicationController
 
     authorize @booking
 
-    redirect_to owned_consoles_path(current_user)
+    redirect_to owned_consoles_path
   end
 
   private

--- a/app/controllers/consoles_controller.rb
+++ b/app/controllers/consoles_controller.rb
@@ -69,7 +69,7 @@ class ConsolesController < ApplicationController
 
   def destroy
     @console.destroy
-    redirect_to owned_consoles_path(current_user)
+    redirect_to owned_consoles_path
   end
 
   private

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -22,7 +22,7 @@
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
             <% if current_user.consoles.count > 0 %>
-              <%= link_to "Dashboard", owned_consoles_path(current_user), class: "dropdown-item" %>
+              <%= link_to "Dashboard", owned_consoles_path, class: "dropdown-item" %>
             <% end %>
             <a class="dropdown-item" href="/consoles/new">Submit</a>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,14 +6,14 @@ Rails.application.routes.draw do
     resources :bookings, only: [:new, :create]
   end
 
-  resources :bookings, except: [:new, :create, :index] do
+  resources :bookings, except: [:create, :index] do
     member do
       post :approve
       post :deny
     end
   end
 
-  get '/users/:id/bookings/', to: "bookings#index", as: :booked_consoles
-  get '/users/:id/consoles/', to: "pages#owned_consoles", as: :owned_consoles
+  get '/users/bookings/', to: "bookings#index", as: :booked_consoles
+  get '/users/consoles/', to: "pages#owned_consoles", as: :owned_consoles
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
In pages routes : owned_consoles_path and booked_consoles_path don't not actually require user_id
The path was simplified (ex below)
booked_consoles GET    /users/bookings(.:format)

Delete new_console_path